### PR TITLE
Update peasant_generator.xml - fix missing generate button

### DIFF
--- a/campaign/peasant_generator.xml
+++ b/campaign/peasant_generator.xml
@@ -99,7 +99,7 @@
 				</script>
 			</basicnumberc>
 			
-			<button_text_large name="generate_button">
+			<button_text name="generate_button">
 				<anchored width="100" height="50">
 					<left anchor="center" offset="-50" />
 					<bottom offset="-25" />
@@ -110,7 +110,7 @@
 						window.onGenerateButtonPressed();
 					end
 				</script>
-			</button_text_large>
+			</button_text>
 
 			<close_charsheet />
 		</sheetdata>


### PR DESCRIPTION
The button_text_large template appears to have been removed causing the generate button to no longer display

```
[6/6/2024 9:20:36 PM] [WARNING]  template: Could not find template (button_text_large) in class (peasant_generator)
[6/6/2024 9:20:36 PM] [ERROR]  Script execution error: [string "FilyPeasants:..cripts/peasant_generator.lua"]:12: attempt to index global 'generate_button' (a nil value)
[6/6/2024 9:20:36 PM] [ERROR]  Script execution error: [string "FilyPeasants:..cripts/peasant_generator.lua"]:12: attempt to index global 'generate_button' (a nil value)
[6/6/2024 9:20:36 PM] [ERROR]  Script execution error: [string "FilyPeasants:..cripts/peasant_generator.lua"]:12: attempt to index global 'generate_button' (a nil value)
```

I changed it to button_text